### PR TITLE
chore: bump to v0.1.6, remove postflight quarantine strip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,13 +124,6 @@ jobs:
 
             app "Pelagos.app"
 
-            # Ad-hoc signed only — remove Gatekeeper quarantine after install.
-            # TODO: remove postflight once Developer ID signing + notarization is in place (epic #225).
-            postflight do
-              system_command "/usr/bin/xattr",
-                args: ["-dr", "com.apple.quarantine", "#{appdir}/Pelagos.app"]
-            end
-
             uninstall quit: "io.pelagos.ui"
 
             zap trash: [

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Pelagos",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "identifier": "io.pelagos.ui",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump for first Developer ID signed + notarized release.
Removes the `postflight` quarantine xattr strip — no longer needed
now that the DMG is properly notarized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)