### PR TITLE
feat(pty): exec into running container via embedded terminal

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -37,6 +37,7 @@ pub fn run() {
             commands::stream_logs,
             commands::stop_logs,
             pty::launch_terminal_window,
+            pty::launch_exec_window,
             pty::pty_start,
             pty::pty_input,
             pty::pty_resize,

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -15,13 +15,26 @@ use tauri::{Emitter, WebviewUrl, WebviewWindowBuilder};
 
 // ── State ─────────────────────────────────────────────────────────────────────
 
-/// Pending run params, held between `launch_terminal_window` and `pty_start`.
+/// What kind of pelagos session to spawn in a terminal window.
+pub enum PtyMode {
+    /// `pelagos run --tty --interactive [opts] <image> [args]`
+    Run {
+        image: String,
+        name: Option<String>,
+        args: Vec<String>,
+        ports: Vec<String>,
+        volumes: Vec<String>,
+    },
+    /// `pelagos exec -i <container> [cmd]`
+    Exec {
+        container: String,
+        cmd: Vec<String>,
+    },
+}
+
+/// Pending session params, held between `launch_*_window` and `pty_start`.
 pub struct PtyParams {
-    pub image: String,
-    pub name: Option<String>,
-    pub args: Vec<String>,
-    pub ports: Vec<String>,
-    pub volumes: Vec<String>,
+    pub mode: PtyMode,
 }
 
 /// Live PTY session — kept alive for resize and input.
@@ -53,10 +66,6 @@ impl PtyState {
 
 /// Open a new terminal window for `pelagos run --tty --interactive image [args]`.
 ///
-/// Stores the run params in [`PtyState`] under a fresh UUID label, then opens a
-/// Tauri [`WebviewWindow`] at `/terminal?label=<uuid>`.  The window's Svelte page
-/// calls [`pty_start`] once xterm.js is mounted.
-///
 /// Frontend: `await invoke('launch_terminal_window', { image, name, args, ports, volumes })`
 #[tauri::command]
 pub fn launch_terminal_window(
@@ -68,29 +77,43 @@ pub fn launch_terminal_window(
     ports: Vec<String>,
     volumes: Vec<String>,
 ) -> Result<String, String> {
+    let title = format!("pelagos — {image}");
+    open_terminal_window(&app, &state, title, PtyMode::Run { image, name, args, ports, volumes })
+}
+
+/// Open a new terminal window for `pelagos exec -i <container> [cmd]`.
+///
+/// `cmd` defaults to `["sh"]` when empty.
+///
+/// Frontend: `await invoke('launch_exec_window', { container, cmd })`
+#[tauri::command]
+pub fn launch_exec_window(
+    app: tauri::AppHandle,
+    state: tauri::State<PtyState>,
+    container: String,
+    cmd: Vec<String>,
+) -> Result<String, String> {
+    let title = format!("pelagos — exec {container}");
+    open_terminal_window(&app, &state, title, PtyMode::Exec { container, cmd })
+}
+
+/// Shared implementation: park params and open a terminal WebviewWindow.
+fn open_terminal_window(
+    app: &tauri::AppHandle,
+    state: &tauri::State<PtyState>,
+    title: String,
+    mode: PtyMode,
+) -> Result<String, String> {
     let label = format!("terminal-{}", uuid::Uuid::new_v4().simple());
-
-    // Park the params until the window calls pty_start.
-    state.0.lock().unwrap().pending.insert(
-        label.clone(),
-        PtyParams {
-            image: image.clone(),
-            name,
-            args,
-            ports,
-            volumes,
-        },
-    );
-
+    state.0.lock().unwrap().pending.insert(label.clone(), PtyParams { mode });
     let url = WebviewUrl::App(format!("/terminal?label={}", label).into());
-    WebviewWindowBuilder::new(&app, &label, url)
-        .title(format!("pelagos — {image}"))
+    WebviewWindowBuilder::new(app, &label, url)
+        .title(title)
         .inner_size(900.0, 600.0)
         .min_inner_size(400.0, 300.0)
         .resizable(true)
         .build()
         .map_err(|e| e.to_string())?;
-
     Ok(label)
 }
 
@@ -124,28 +147,44 @@ pub async fn pty_start(
     // Build the command args before entering spawn_blocking.
     let pelagos = find_pelagos_bin();
     let mut cmd = CommandBuilder::new(&pelagos);
-    cmd.arg("run");
-    cmd.arg("--tty");
-    cmd.arg("--interactive");
-    if let Some(n) = &params.name {
-        cmd.arg("--name");
-        cmd.arg(n);
-    }
-    if !params.ports.is_empty() {
-        for p in &params.ports {
-            cmd.arg("-p");
-            cmd.arg(p);
+    match &params.mode {
+        PtyMode::Run { image, name, args, ports, volumes } => {
+            cmd.arg("run");
+            cmd.arg("--tty");
+            cmd.arg("--interactive");
+            if let Some(n) = name {
+                cmd.arg("--name");
+                cmd.arg(n);
+            }
+            if !ports.is_empty() {
+                for p in ports {
+                    cmd.arg("-p");
+                    cmd.arg(p);
+                }
+                cmd.arg("-n");
+                cmd.arg("pasta");
+            }
+            for v in volumes {
+                cmd.arg("-v");
+                cmd.arg(v);
+            }
+            cmd.arg(image);
+            for a in args {
+                cmd.arg(a);
+            }
         }
-        cmd.arg("-n");
-        cmd.arg("pasta");
-    }
-    for v in &params.volumes {
-        cmd.arg("-v");
-        cmd.arg(v);
-    }
-    cmd.arg(&params.image);
-    for a in &params.args {
-        cmd.arg(a);
+        PtyMode::Exec { container, cmd: exec_cmd } => {
+            cmd.arg("exec");
+            cmd.arg("-i");
+            cmd.arg(container);
+            if exec_cmd.is_empty() {
+                cmd.arg("sh");
+            } else {
+                for a in exec_cmd {
+                    cmd.arg(a);
+                }
+            }
+        }
     }
 
     // PTY allocation and process spawn are blocking syscalls (openpty, fork,
@@ -322,11 +361,13 @@ mod tests {
             map.pending.insert(
                 label.clone(),
                 PtyParams {
-                    image: "alpine:latest".into(),
-                    name: Some("my-container".into()),
-                    args: vec!["/bin/sh".into()],
-                    ports: vec!["8080:80".into()],
-                    volumes: vec![],
+                    mode: PtyMode::Run {
+                        image: "alpine:latest".into(),
+                        name: Some("my-container".into()),
+                        args: vec!["/bin/sh".into()],
+                        ports: vec!["8080:80".into()],
+                        volumes: vec![],
+                    },
                 },
             );
             assert!(map.pending.contains_key(&label));
@@ -335,16 +376,52 @@ mod tests {
         {
             let mut map = state.0.lock().unwrap();
             let params = map.pending.remove(&label).expect("params should exist");
-            assert_eq!(params.image, "alpine:latest");
-            assert_eq!(params.name.as_deref(), Some("my-container"));
-            assert_eq!(params.args, vec!["/bin/sh"]);
-            assert_eq!(params.ports, vec!["8080:80"]);
-            assert!(params.volumes.is_empty());
+            match params.mode {
+                PtyMode::Run { image, name, args, ports, volumes } => {
+                    assert_eq!(image, "alpine:latest");
+                    assert_eq!(name.as_deref(), Some("my-container"));
+                    assert_eq!(args, vec!["/bin/sh"]);
+                    assert_eq!(ports, vec!["8080:80"]);
+                    assert!(volumes.is_empty());
+                }
+                _ => panic!("expected Run mode"),
+            }
         }
 
         {
             let map = state.0.lock().unwrap();
             assert!(map.pending.is_empty());
+        }
+    }
+
+    #[test]
+    fn pending_params_exec_mode() {
+        let state = PtyState::new();
+        let label = "terminal-exec-test".to_string();
+
+        {
+            let mut map = state.0.lock().unwrap();
+            map.pending.insert(
+                label.clone(),
+                PtyParams {
+                    mode: PtyMode::Exec {
+                        container: "my-container".into(),
+                        cmd: vec!["bash".into()],
+                    },
+                },
+            );
+        }
+
+        {
+            let mut map = state.0.lock().unwrap();
+            let params = map.pending.remove(&label).expect("params should exist");
+            match params.mode {
+                PtyMode::Exec { container, cmd } => {
+                    assert_eq!(container, "my-container");
+                    assert_eq!(cmd, vec!["bash"]);
+                }
+                _ => panic!("expected Exec mode"),
+            }
         }
     }
 

--- a/src/lib/components/ContainerRow.svelte
+++ b/src/lib/components/ContainerRow.svelte
@@ -7,7 +7,7 @@
   export let editMode = false;
   export let checked = false;
 
-  const dispatch = createEventDispatcher<{ stop: string; remove: string; toggle: string; logs: string }>();
+  const dispatch = createEventDispatcher<{ stop: string; remove: string; toggle: string; logs: string; exec: string }>();
 
   function age(iso: string): string {
     const s = Math.floor((Date.now() - new Date(iso).getTime()) / 1000);
@@ -47,6 +47,7 @@
     {#if !editMode}
       <button class="logs-btn" on:click={() => dispatch('logs', container.name)}>Logs</button>
       {#if container.status === 'running'}
+        <button class="exec-btn" on:click={() => dispatch('exec', container.name)}>Exec</button>
         <button on:click={() => dispatch('stop', container.name)}>Stop</button>
       {/if}
       <button class="danger" on:click={() => dispatch('remove', container.name)}>Remove</button>
@@ -92,4 +93,6 @@
   button.danger:hover  { background: #7f1d1d; border-color: #991b1b; color: #fca5a5; }
   button.logs-btn      { color: #93c5fd; border-color: #1d3a5c; }
   button.logs-btn:hover { background: #1d3a5c; border-color: #3b82f6; }
+  button.exec-btn      { color: #86efac; border-color: #14532d; }
+  button.exec-btn:hover { background: #14532d; border-color: #22c55e; }
 </style>

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -30,6 +30,11 @@ export const runContainer      = (image: string, name: string | null, args: stri
 export const launchTerminalWindow = (image: string, name: string | null, args: string[], ports: string[], volumes: string[]) =>
   invoke<string>('launch_terminal_window', { image, name, args, ports, volumes });
 
+/// Open an embedded terminal window for `pelagos exec -i <container> [cmd]`.
+/// Returns the window label.
+export const launchExecWindow = (container: string, cmd: string[]) =>
+  invoke<string>('launch_exec_window', { container, cmd });
+
 export interface ImageInfo {
   reference: string;
   digest:    string;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,6 +12,11 @@
   // Logs panel state
   let logsContainer: ContainerInfo | null = null;
 
+  // Exec modal state
+  let execContainer: string | null = null;
+  let execCmd = 'sh';
+  let execInput: HTMLInputElement;
+
   // Filter + sort state
   let runningOnly = true;
 
@@ -47,12 +52,27 @@
     logsContainer = $containers.find(c => c.name === name) ?? null;
   }
 
-  async function handleExec(name: string) {
+  function handleExec(name: string) {
+    execContainer = name;
+    execCmd = 'sh';
+    // Focus the input after the modal renders.
+    setTimeout(() => execInput?.focus(), 0);
+  }
+
+  async function submitExec() {
+    if (!execContainer) return;
+    const name = execContainer;
+    const cmd = execCmd.trim().split(/\s+/).filter(Boolean);
+    execContainer = null;
     try {
-      await launchExecWindow(name, []);
+      await launchExecWindow(name, cmd.length ? cmd : ['sh']);
     } catch (e) {
       error.set(String(e));
     }
+  }
+
+  function cancelExec() {
+    execContainer = null;
   }
 
   function setSort(col: SortCol) {
@@ -218,6 +238,28 @@
 
   </div>
 </div>
+
+<!-- exec command modal -->
+{#if execContainer}
+  <!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
+  <div class="modal-backdrop" on:click={cancelExec}>
+    <div class="modal" on:click|stopPropagation>
+      <p class="modal-title">Exec into <strong>{execContainer}</strong></p>
+      <input
+        bind:this={execInput}
+        bind:value={execCmd}
+        class="modal-input"
+        type="text"
+        placeholder="sh"
+        on:keydown={e => { if (e.key === 'Enter') submitExec(); else if (e.key === 'Escape') cancelExec(); }}
+      />
+      <div class="modal-actions">
+        <button class="modal-cancel" on:click={cancelExec}>Cancel</button>
+        <button class="modal-submit" on:click={submitExec}>Open Terminal</button>
+      </div>
+    </div>
+  </div>
+{/if}
 
 <p class="attribution">Photo: Jeri Leandera (CC BY-SA)</p>
 <p class="attribution attribution-left">Icon: hibernut / Noun Project (CC BY)</p>
@@ -387,4 +429,66 @@
     right: unset;
     left: 12px;
   }
+
+  .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+  }
+  .modal {
+    background: #1a1f2e;
+    border: 1px solid #374151;
+    border-radius: 8px;
+    padding: 20px 24px;
+    width: 360px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .modal-title {
+    margin: 0;
+    font-size: 0.85rem;
+    color: #d1d5db;
+  }
+  .modal-title strong { color: #f0f0f0; }
+  .modal-input {
+    background: #0d1117;
+    border: 1px solid #374151;
+    border-radius: 4px;
+    color: #f0f0f0;
+    font-family: ui-monospace, monospace;
+    font-size: 0.85rem;
+    padding: 6px 10px;
+    width: 100%;
+  }
+  .modal-input:focus { outline: none; border-color: #3b82f6; }
+  .modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+  .modal-cancel {
+    background: transparent;
+    border: 1px solid #374151;
+    border-radius: 4px;
+    color: #9ca3af;
+    cursor: pointer;
+    font-size: 0.75rem;
+    padding: 4px 12px;
+  }
+  .modal-cancel:hover { border-color: #6b7280; color: #f0f0f0; }
+  .modal-submit {
+    background: #14532d;
+    border: 1px solid #22c55e;
+    border-radius: 4px;
+    color: #86efac;
+    cursor: pointer;
+    font-size: 0.75rem;
+    padding: 4px 12px;
+  }
+  .modal-submit:hover { background: #166534; }
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,7 +4,7 @@
   import ContainerRow from '$lib/components/ContainerRow.svelte';
   import ImagePane from '$lib/components/ImagePane.svelte';
   import LogsPanel from '$lib/components/LogsPanel.svelte';
-  import { stopContainer, removeContainer } from '$lib/ipc';
+  import { stopContainer, removeContainer, launchExecWindow } from '$lib/ipc';
   import type { ContainerInfo } from '$lib/ipc';
 
   let stopPolling: () => void;
@@ -45,6 +45,14 @@
 
   function handleLogs(name: string) {
     logsContainer = $containers.find(c => c.name === name) ?? null;
+  }
+
+  async function handleExec(name: string) {
+    try {
+      await launchExecWindow(name, []);
+    } catch (e) {
+      error.set(String(e));
+    }
   }
 
   function setSort(col: SortCol) {
@@ -177,6 +185,7 @@
                 on:remove={e => handleRemove(e.detail)}
                 on:toggle={e => toggleSelected(e.detail)}
                 on:logs={e => handleLogs(e.detail)}
+              on:exec={e => handleExec(e.detail)}
               />
             {/each}
           </tbody>


### PR DESCRIPTION
## Summary

- Adds an **Exec** button (green tint) to every running container row
- Opens a new embedded terminal window running `pelagos exec -i <container> sh`
- Reuses all existing PTY infrastructure — no duplication

## Changes

**Rust (`src-tauri/src/pty.rs`, `lib.rs`)**
- `PtyParams` now carries `PtyMode` enum (`Run { image, name, args, ports, volumes }` | `Exec { container, cmd }`) instead of flat run-specific fields
- `pty_start` branches on mode to build `pelagos run --tty --interactive` or `pelagos exec -i`
- `launch_exec_window` added; both commands share `open_terminal_window` helper
- All 6 unit tests updated/passing

**Frontend**
- `launchExecWindow` added to `ipc.ts`
- `exec` event dispatched from `ContainerRow.svelte` (running only, green-tinted button)
- `handleExec` added to `+page.svelte`

## Test plan

- [ ] `cargo check` and `cargo test` pass (verified locally)
- [ ] Exec button appears only on running containers
- [ ] Clicking Exec opens a terminal window with a shell prompt
- [ ] PTY resize, input, and close work the same as Run sessions
- [ ] Run Interactive still works (no regression)

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)